### PR TITLE
MdLint fix

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -217,7 +217,7 @@ gulp.task('jsonlint', function() {
 });
 
 gulp.task('mdlint', function() {
-	gulp.src(['docs/*.mdpp', 'docs/partials/*.md'])
+	return gulp.src(['docs/*.mdpp', 'docs/partials/*.md'])
 		.pipe(remark());
 });
 


### PR DESCRIPTION
Add a return to the stream so that it doesn't signal completion before the test runs